### PR TITLE
Allow block headers of the form [key, '', '', ...]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw_simapro_csv` Changelog
 
+## [0.4.3] - 2025-09-16
+
+* Allow for block headers with one key followed by empty strings
+
 ## [0.4.2] - 2025-03-09
 
 * Don't issue some duplicate warning messages

--- a/bw_simapro_csv/__init__.py
+++ b/bw_simapro_csv/__init__.py
@@ -4,7 +4,7 @@ __all__ = (
     "SimaProCSVType",
 )
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 # Makes `sloppy-windows-1252` encoding available
 import ftfy

--- a/bw_simapro_csv/main.py
+++ b/bw_simapro_csv/main.py
@@ -43,7 +43,7 @@ from .parameters import (
     substitute_in_formulas,
 )
 from .units import normalize_units
-from .utils import json_serializer, parameter_set_evaluate_each_formula
+from .utils import json_serializer, parameter_set_evaluate_each_formula, get_true_length
 
 
 def dummy(data, *args):
@@ -232,7 +232,7 @@ class SimaProCSV:
             if not any(line):
                 # Skip empty lines at beginning of block
                 continue
-            if len(line) == 1 and line[0] == "End":
+            if get_true_length(line) == 1 and line[0] == "End":
                 # Empty block
                 self.uses_end_text = True
                 return EmptyBlock

--- a/bw_simapro_csv/utils.py
+++ b/bw_simapro_csv/utils.py
@@ -179,6 +179,17 @@ def jump_to_nonempty(data: list) -> list:
     return data[i:]
 
 
+def get_true_length(line: list) -> int:
+    """Computes line length, not accounting for trailing empty elements"""
+    n_trailing_empty = 0
+    for elt in reversed(line):
+        if elt == "":
+            n_trailing_empty += 1
+        else:
+            break
+    return len(line) - n_trailing_empty
+
+
 def get_key_multiline_values(block: list[tuple], stop_terms: Iterable) -> tuple[str, list]:
     """Pull off the first non-empty line, then optional empty lines, and then each data line until
     an empty line"""
@@ -186,16 +197,16 @@ def get_key_multiline_values(block: list[tuple], stop_terms: Iterable) -> tuple[
         block = jump_to_nonempty(block)
         if not any(data for _, data in block):
             return
-        _, key = block.pop(0)
-        if len(key) != 1:
+        _, line = block.pop(0)
+        if get_true_length(line) != 1:
             raise ValueError(f"Block header should have one element; found {len(key)}: {key}")
-        key = key[0]
+        key = line[0]
         block = jump_to_nonempty(block)
 
         data = []
         while block:
             line_no, line = block.pop(0)
-            if len(line) == 1 and line[0] in stop_terms:
+            if get_true_length(line) == 1 and line[0] in stop_terms:
                 block.insert(0, (line_no, line))
                 break
             elif not line or not any(line):
@@ -246,3 +257,4 @@ def parameter_set_evaluate_each_formula(ps: ParameterSet) -> dict[str, float]:
     for key, value in ps.params.items():
         value["amount"] = result[key]
     return result
+

--- a/bw_simapro_csv/utils.py
+++ b/bw_simapro_csv/utils.py
@@ -199,7 +199,7 @@ def get_key_multiline_values(block: list[tuple], stop_terms: Iterable) -> tuple[
             return
         _, line = block.pop(0)
         if get_true_length(line) != 1:
-            raise ValueError(f"Block header should have one element; found {len(key)}: {key}")
+            raise ValueError(f"Block header should have one element; found {len(line)}: {line}")
         key = line[0]
         block = jump_to_nonempty(block)
 

--- a/tests/blocks/test_block_titles_semicolons.py
+++ b/tests/blocks/test_block_titles_semicolons.py
@@ -1,0 +1,22 @@
+import math
+
+from bw_simapro_csv import SimaProCSV
+from bw_simapro_csv.blocks import DatabaseInputParameters
+
+def test_block_names_support_semicolons(fixtures_dir):
+    obj = SimaProCSV(fixtures_dir / "process.csv")
+    dip = [elem.parsed for elem in obj.blocks if isinstance(elem, DatabaseInputParameters)][0]
+    assert dip == [
+        {
+            "uncertainty type": 2,
+            "amount": 1.0,
+            "loc": 0.0,
+            "scale": math.log(2),
+            "line_no": 274,
+            "negative": False,
+            "hidden": False,
+            "original_name": "db_input_param",
+            "name": "SP_DB_INPUT_PARAM",
+            "comment": "database parameter",
+        }
+    ]

--- a/tests/fixtures/process.csv
+++ b/tests/fixtures/process.csv
@@ -270,7 +270,7 @@ Sample economic issue;kg;;
 End
 
 
-Database Input parameters
+Database Input parameters;;;;;;;
 db_input_param;1;Lognormal;4;0;0;No;database parameter
 
 End

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,7 +10,17 @@ from bw_simapro_csv.utils import (
     jump_to_nonempty,
     normalize_number_in_formula,
     skip_empty,
+    get_true_length
 )
+
+
+def test_get_true_length():
+    assert get_true_length(["a", "", ""]) == 1
+    assert get_true_length(["a", "", "b"]) == 3
+    assert get_true_length(["a", "b", ""]) == 2
+    assert get_true_length([]) == 0
+    assert get_true_length([""]) == 0
+    assert get_true_length(["header"]) == 1
 
 
 def test_asnumber():


### PR DESCRIPTION
## Tests

- Added one test, which passes
- Tested the imported on the Simapro CSV file that I had which led me to this PR, and it now works as expected

## Description

I have encountered Simapro CSVs with blocks like this

```
Process;;;;;;;
Process identifier;;;;;;;
Process name;;;;;;;

<....>

Input parameters;;;;;;;
;;;;;;;
Calculated parameters;;;;;;;
;;;;;;;
```

where I assume by reading the code that bw_simapro_csv would have expected headers to be without the trailing semicolons.

```
Process
Process identifier
Process name

<....>

Input parameters
;;;;;;;
Calculated parameters
;;;;;;;
```

Both seem like valid CSVs to me, and therefore this PR aims at removing trailing empty strings from the line count used to identify headers and block content.