### PR TITLE
Parse Product stage blocks instead of discarding them

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # `bw_simapro_csv` Changelog
 
+## [Unreleased]
+
+* Parse `Product stage` blocks (assemblies and life cycles) into a `ProductStage` block, instead of routing them to a no-op that discarded their content. `{product stages}` exports now retain all of their blocks, and a `ProductStage` carries its reference output and component sections (`Materials/assemblies`, `Processes`, ...) the same way a `Process` carries its sub-blocks.
+
 ## [0.4.3] - 2025-09-16
 
 * [#24 - Allow for block headers with one key followed by empty strings](https://github.com/brightway-lca/bw_simapro_csv/pull/24)

--- a/bw_simapro_csv/blocks/__init__.py
+++ b/bw_simapro_csv/blocks/__init__.py
@@ -10,6 +10,7 @@ __all__ = (
     "Method",
     "NormalizationWeightingSet",
     "Process",
+    "ProductStage",
     "Products",
     "ProjectCalculatedParameters",
     "ProjectInputParameters",
@@ -35,6 +36,7 @@ from .method import Method
 from .normalization_weighting_set import NormalizationWeightingSet
 from .parameters import DatabaseInputParameters, ProjectInputParameters
 from .process import Process
+from .product_stage import ProductStage
 from .products import Products
 from .quantities import Quantities
 from .system_description import SystemDescription

--- a/bw_simapro_csv/blocks/product_stage.py
+++ b/bw_simapro_csv/blocks/product_stage.py
@@ -1,0 +1,146 @@
+from ..constants import MAGIC
+from ..utils import add_amount_or_formula, get_key_multiline_values, jump_to_nonempty, skip_empty
+from .base import SimaProCSVBlock
+from .calculated_parameters import DatasetCalculatedParameters
+from .parameters import DatasetInputParameters
+from .technosphere_edges import TechnosphereEdges
+
+
+class ProductStageReference(SimaProCSVBlock):
+    """The reference output of a product stage - its ``Products`` line.
+
+    A product-stage reference row is laid out differently from a process
+    ``Products`` row. A process row carries allocation and waste-type columns:
+
+    ```
+    name;unit;amount;allocation;waste type;category;comment
+    ```
+
+    A product stage (an assembly, life cycle, ...) is never allocated, so its
+    reference row omits those columns:
+
+    ```
+    name;unit;amount;category;comment
+    ```
+
+    Reusing the process ``Products`` parser here would read the wrong columns (and
+    index past the end of the row), so the product stage gets its own reference
+    parser. Indices past the row length degrade to empty strings rather than
+    raising, since trailing columns are routinely dropped by SimaPro.
+    """
+
+    def __init__(self, block: list[tuple], header: dict, **kwargs):
+        self.parsed = []
+        self.has_formula = True
+
+        for line_no, line in skip_empty(block):
+            self.parsed.append(
+                add_amount_or_formula(
+                    {
+                        "name": line[0],
+                        "unit": line[1] if len(line) > 1 else "",
+                        "category": line[3] if len(line) > 3 else "",
+                        "comment": line[4] if len(line) > 4 else "",
+                        "line_no": line_no,
+                    },
+                    line[2] if len(line) > 2 else "",
+                    header["decimal_separator"],
+                )
+            )
+
+
+class RawProductStageSection(SimaProCSVBlock):
+    """Fallback for a product-stage sub-section without a dedicated parser.
+
+    SimaPro product stages can carry scenario sections (disposal, reuse, ...)
+    whose exact column layout we do not model. Rather than dropping them - the
+    behaviour this class replaces routed the whole product stage to a no-op that
+    discarded all of its content - we keep their rows verbatim so the block still
+    carries everything the file held.
+    """
+
+    def __init__(self, block: list[tuple], header: dict, category: str, **kwargs):
+        self.category = category
+        self.parsed = [
+            {"line_no": line_no, "fields": list(line)} for line_no, line in skip_empty(block)
+        ]
+
+
+# SimaPro product-stage sub-sections. The reference output is the stage's own
+# ``Products`` row; every component section (sub-assemblies, processes, scenarios)
+# shares the technosphere-edge row layout ``name;unit;amount;uncertainty...;comment``.
+# Sections we have not seen a sample of fall back to ``RawProductStageSection`` so
+# nothing is silently dropped.
+PRODUCT_STAGE_BLOCK_MAPPING = {
+    "Products": ProductStageReference,
+    "Materials/assemblies": TechnosphereEdges,
+    "Processes": TechnosphereEdges,
+    "Assembly": TechnosphereEdges,
+    "Subassemblies": TechnosphereEdges,
+    "Additional life cycles": TechnosphereEdges,
+    "Disassembly": TechnosphereEdges,
+    "Reuse": TechnosphereEdges,
+    "Disposal scenario": TechnosphereEdges,
+    "Waste/Disposal scenario": TechnosphereEdges,
+    "Waste scenario": TechnosphereEdges,
+    "Input parameters": DatasetInputParameters,
+    "Calculated parameters": DatasetCalculatedParameters,
+}
+
+
+class ProductStage(SimaProCSVBlock):
+    """A SimaPro product stage: an assembly, life cycle, or scenario.
+
+    ``{product stages}`` exports interleave these blocks with ordinary
+    ``Process`` blocks. SimaPro builds the modelled product by composing *named*
+    references: an assembly's ``Materials/assemblies`` and ``Processes`` sections
+    point at other product stages and at processes by name (a product stage has
+    no ``Process identifier``), and its ``Products`` section is the stage's
+    reference output. Before this class, ``Product stage`` blocks were routed to a
+    no-op and their entire content was discarded; we now parse them the same way
+    ``Process`` does - metadata pairs, then typed sub-blocks - so downstream code
+    can read ``.parsed["metadata"]`` and ``.blocks[...]`` symmetrically with a
+    process. A product stage is identified by its reference-product name.
+    """
+
+    def __init__(self, block: list[list], header: dict):
+        self.parsed = {"metadata": {}}
+        self.blocks = {}
+        self.header = header
+
+        block = jump_to_nonempty(block)
+
+        # Metadata is stored as alternating key / value lines (the value may be
+        # blank), up to the first sub-block header. Unlike a process, a product
+        # stage carries no Date/Infrastructure/Literature-reference metadata, so a
+        # plain key/value pull is enough.
+        self.index = 0
+        while (
+            self.index < len(block)
+            and block[self.index][1]
+            and block[self.index][1][0] not in PRODUCT_STAGE_BLOCK_MAPPING
+        ):
+            key, value = self.pull_metadata_pair(block)
+            if value:
+                self.parsed["metadata"][key] = value
+
+        for block_type, block_data in get_key_multiline_values(
+            block[self.index :], stop_terms=PRODUCT_STAGE_BLOCK_MAPPING
+        ):
+            if not block_data:
+                continue
+            block_class = PRODUCT_STAGE_BLOCK_MAPPING.get(block_type, RawProductStageSection)
+            self.blocks[block_type] = block_class(
+                header=header, block=block_data, category=block_type
+            )
+
+    def pull_metadata_pair(self, block: list[list]) -> tuple[str, str]:
+        """Read a ``key`` / ``value`` metadata pair, then skip to the next
+        non-empty line. The value may be blank or span multiple cells on its line."""
+        key = block[self.index][1][0]
+        value_line = block[self.index + 1][1] if self.index + 1 < len(block) else []
+        value = MAGIC.join([elem for elem in value_line if elem]) if value_line else ""
+        self.index += 2
+        while self.index < len(block) and not any(block[self.index][1]):
+            self.index += 1
+        return key, value

--- a/bw_simapro_csv/main.py
+++ b/bw_simapro_csv/main.py
@@ -25,6 +25,7 @@ from .blocks import (
     Method,
     NormalizationWeightingSet,
     Process,
+    ProductStage,
     ProjectCalculatedParameters,
     ProjectInputParameters,
     Quantities,
@@ -43,12 +44,7 @@ from .parameters import (
     substitute_in_formulas,
 )
 from .units import normalize_units
-from .utils import json_serializer, parameter_set_evaluate_each_formula, get_true_length
-
-
-def dummy(data, *args):
-    return data
-
+from .utils import get_true_length, json_serializer, parameter_set_evaluate_each_formula
 
 CONTROL_BLOCK_MAPPING = {
     "Database Calculated parameters": DatabaseCalculatedParameters,
@@ -57,7 +53,7 @@ CONTROL_BLOCK_MAPPING = {
     "Project Input parameters": ProjectInputParameters,
     "Project Calculated parameters": ProjectCalculatedParameters,
     "Quantities": Quantities,
-    "Product stage": dummy,
+    "Product stage": ProductStage,
     "Units": Units,
     "Process": Process,
     "Method": Method,

--- a/bw_simapro_csv/units.py
+++ b/bw_simapro_csv/units.py
@@ -6,16 +6,19 @@ from .blocks import (
     GenericUncertainBiosphere,
     Process,
     Products,
+    ProductStage,
     SimaProCSVBlock,
     TechnosphereEdges,
     Units,
     WasteTreatment,
 )
+from .blocks.product_stage import ProductStageReference
 from .uncertainty import recalculate_uncertainty_distribution
 
 HAS_UNITS = (
     GenericUncertainBiosphere,
     Products,
+    ProductStageReference,
     TechnosphereEdges,
     WasteTreatment,
 )
@@ -80,7 +83,7 @@ def normalize_units(blocks: list[SimaProCSVBlock]) -> None:
                 d=mapping["line_no"],
             )
 
-    for process_block in filter(lambda x: isinstance(x, Process), blocks):
+    for process_block in filter(lambda x: isinstance(x, (Process, ProductStage)), blocks):
         for block in filter(lambda x: isinstance(x, HAS_UNITS), process_block.blocks.values()):
             for obj in block.parsed:
                 try:

--- a/tests/blocks/test_product_stage.py
+++ b/tests/blocks/test_product_stage.py
@@ -1,0 +1,100 @@
+from io import StringIO
+
+from bw_simapro_csv import SimaProCSV
+from bw_simapro_csv.blocks import Process, ProductStage
+
+# A minimal `{product stages}` export: one ordinary process plus one assembly
+# product stage that references the process (by name) and a sub-assembly.
+STAGES_CSV = """{SimaPro 10.2.0.1}
+{product stages}
+{Project: Demo}
+{CSV Format version: 9.0.0}
+{CSV separator: Semicolon}
+{Decimal separator: .}
+{Date separator: /}
+{Short date format: M/d/yyyy}
+
+Process
+
+Category type
+material
+
+Process identifier
+FOO000000000000000001
+
+Products
+Widget;kg;1;100;not defined;Cat\\Sub;a comment
+
+Materials/fuels
+
+End
+
+Product stage
+
+Category type
+assembly
+
+Status
+
+
+Products
+My Assembly (Top);p;1;Cat\\Path;1234 units;
+
+Materials/assemblies
+Sub Assembly X;p;1234;Undefined;0;0;0;;
+
+Processes
+Widget;kg;7120/1234;Undefined;0;0;0;a note;
+
+Input parameters
+
+Calculated parameters
+
+End
+"""
+
+
+def _parse():
+    return SimaProCSV(StringIO(STAGES_CSV), write_logs=False, stderr_logs=False)
+
+
+def test_product_stage_is_parsed_not_dropped():
+    sp = _parse()
+    stages = [b for b in sp.blocks if isinstance(b, ProductStage)]
+    assert len(stages) == 1
+    # A product stage must not be mistaken for a process.
+    assert not any(isinstance(b, ProductStage) and isinstance(b, Process) for b in sp.blocks)
+
+
+def test_product_stage_metadata_and_sections():
+    sp = _parse()
+    stage = next(b for b in sp.blocks if isinstance(b, ProductStage))
+    assert stage.parsed["metadata"]["Category type"] == "assembly"
+    # Blank-valued metadata (Status) is dropped, like a process.
+    assert "Status" not in stage.parsed["metadata"]
+    assert set(stage.blocks) == {"Products", "Materials/assemblies", "Processes"}
+
+
+def test_product_stage_reference_row():
+    sp = _parse()
+    stage = next(b for b in sp.blocks if isinstance(b, ProductStage))
+    ref = stage.blocks["Products"].parsed[0]
+    # Product-stage reference layout is name;unit;amount;category;comment - no
+    # allocation/waste-type columns, so the category lands in column 3.
+    assert ref["name"] == "My Assembly (Top)"
+    assert ref["unit"] == "p"
+    assert ref["amount"] == 1.0
+    assert ref["category"] == "Cat\\Path"
+    assert ref["comment"] == "1234 units"
+
+
+def test_product_stage_components_reference_by_name():
+    sp = _parse()
+    stage = next(b for b in sp.blocks if isinstance(b, ProductStage))
+    sub = stage.blocks["Materials/assemblies"].parsed[0]
+    assert sub["name"] == "Sub Assembly X"
+    assert sub["amount"] == 1234.0
+    proc = stage.blocks["Processes"].parsed[0]
+    # An expression amount is kept as a formula, not evaluated.
+    assert proc["name"] == "Widget"
+    assert proc["formula"] == "7120/1234"


### PR DESCRIPTION
`{product stages}` exports (SimaProCSVType.stages) interleave ordinary Process blocks with Product stage blocks (assemblies, life cycles). These were mapped to a no-op that returned the raw rows and dropped all their structure, so an export's assembled products - what an impact analysis is actually run on - were lost.

Add a ProductStage block that parses a product stage the same way Process does: metadata pairs, then typed sub-blocks. Its reference output uses a ProductStageReference parser (the product-stage Products row omits the allocation/waste-type columns a process row carries), and its component sections (Materials/assemblies, Processes, and life-cycle/scenario sections) reuse TechnosphereEdges; unrecognised sections fall back to a raw capture so nothing is dropped. Wire it into CONTROL_BLOCK_MAPPING, export it from blocks, and extend normalize_units to fold component/reference unit factors.